### PR TITLE
Useful extensions

### DIFF
--- a/xtrabackup/backup_tools.py
+++ b/xtrabackup/backup_tools.py
@@ -196,7 +196,7 @@ class BackupTool:
 
     def load_incremental_data(self):
         try:
-            self.base_dir = filesystem_utils.retrieve_value_from_file(
+            self.backup_repository = filesystem_utils.retrieve_value_from_file(
                 '/var/tmp/pyxtrabackup-incremental',
                 '^BASEDIR=(.*)$')
             self.last_lsn = filesystem_utils.retrieve_value_from_file(
@@ -231,12 +231,12 @@ class BackupTool:
                                  workdir, user, password, threads):
         self.check_prerequisites(repository)
         self.prepare_workdir(workdir)
-        self.prepare_repository(repository, True)
         if incremental:
             self.load_incremental_data()
             self.prepare_archive_name(incremental, True)
             self.exec_incremental_backup(user, password, threads)
         else:
+            self.prepare_repository(repository, True)
             self.prepare_archive_name(incremental, True)
             self.exec_full_backup(user, password, threads)
         self.save_incremental_data(incremental)

--- a/xtrabackup/filesystem_utils.py
+++ b/xtrabackup/filesystem_utils.py
@@ -93,3 +93,8 @@ def split_path(path):
 def get_prefixed_file_in_dir(directory, prefix):
     files = glob(''.join([directory, '/', prefix, '*']))
     return files[0]
+
+def get_prefixed_files_in_dir(directory, prefix):
+    files = glob(''.join([directory, '/', prefix, '*']))
+    return files
+

--- a/xtrabackup/restoration.py
+++ b/xtrabackup/restoration.py
@@ -11,7 +11,8 @@ Usage:
 [--log-file=<log>] \
 [--out-file=<log>] \
 [--backup-threads=<threads>] \
-[--uncompressed-archives]
+[--uncompressed-archives] \
+[--without-stop-mysql] \
     pyxtrabackup-restore (-h | --help)
     pyxtrabackup --version
 
@@ -44,6 +45,10 @@ Options:
     --uncompressed-archives                     \
     Specify that the backup archives are not compressed. \
 Use this option if you did backup with --no-compress.
+    --without-stop-mysql                        \
+    Does not stop the server for restoration. \
+Ensure that --data-dir is defined to a directory differ from data directory of running MySQL server.
+
 
 """
 from docopt import docopt
@@ -62,6 +67,7 @@ def main():
         restore_tool.start_restoration(arguments['--base-archive'],
                                        arguments['--incremental-archive'],
                                        arguments['--tmp-dir'],
+                                       arguments['--without-stop-mysql'],
                                        arguments['--restart'])
     except Exception:
         logger = logging.getLogger(__name__)

--- a/xtrabackup/restoration_tools.py
+++ b/xtrabackup/restoration_tools.py
@@ -67,7 +67,7 @@ class RestorationTool:
             repository, archive_name = filesystem_utils.split_path(
                 incremental_archive)
             incremental_target = int(archive_name.split('_')[1])
-            for step in range(1, incremental_target + 1):
+            for step in range(0, incremental_target + 1):
                 self.apply_incremental_backup(repository, step)
         except:
             self.logger.error(

--- a/xtrabackup/restoration_tools.py
+++ b/xtrabackup/restoration_tools.py
@@ -140,14 +140,18 @@ class RestorationTool:
         filesystem_utils.delete_directory_if_exists(self.workdir)
 
     def start_restoration(self, base_archive, incremental_archive,
-                          workdir, restart_service):
+                          workdir, without_stop_service, restart_service):
         self.prepare_workdir(workdir)
-        self.stop_service()
+        if not without_stop_service:
+            self.stop_service()
         self.clean_data_dir()
         self.restore_base_backup(base_archive)
         self.restore_incremental_backups(incremental_archive)
         self.prepare_data_dir()
         self.set_data_dir_permissions()
         self.clean()
-        if restart_service:
-            self.start_service()
+         if restart_service:
+            if without_stop_service:
+                self.logger.warning('Both arguments --without-stop-mysql and --restart are used. --restart will be ignored.')
+            else:
+                self.start_service()

--- a/xtrabackup/restoration_tools.py
+++ b/xtrabackup/restoration_tools.py
@@ -150,8 +150,9 @@ class RestorationTool:
         self.prepare_data_dir()
         self.set_data_dir_permissions()
         self.clean()
-         if restart_service:
+        if restart_service:
             if without_stop_service:
                 self.logger.warning('Both arguments --without-stop-mysql and --restart are used. --restart will be ignored.')
             else:
                 self.start_service()
+


### PR DESCRIPTION
To be able to restore a backup, all incremental should be in the same directory than the base backup. Only backups of one backup chain should be in one directory, also if there are multiple chains per day.
