### PR TITLE
Pass name of service to stop/start as an optional argument

### DIFF
--- a/xtrabackup/restoration.py
+++ b/xtrabackup/restoration.py
@@ -11,7 +11,8 @@ Usage:
 [--log-file=<log>] \
 [--out-file=<log>] \
 [--backup-threads=<threads>] \
-[--uncompressed-archives]
+[--uncompressed-archives] \
+[--service-name=<name>]
     pyxtrabackup-restore (-h | --help)
     pyxtrabackup --version
 
@@ -44,6 +45,8 @@ Options:
     --uncompressed-archives                     \
     Specify that the backup archives are not compressed. \
 Use this option if you did backup with --no-compress.
+    --service-name=<name>                      \
+    Name of the mysql service to stop/start [default: mysql].
 
 """
 from docopt import docopt
@@ -57,7 +60,8 @@ def main():
     restore_tool = RestorationTool(arguments['--log-file'],
                                    arguments['--out-file'],
                                    arguments['--data-dir'],
-                                   arguments['--uncompressed-archives'])
+                                   arguments['--uncompressed-archives'],
+                                   arguments['--service-name'])
     try:
         restore_tool.start_restoration(arguments['--base-archive'],
                                        arguments['--incremental-archive'],

--- a/xtrabackup/restoration_tools.py
+++ b/xtrabackup/restoration_tools.py
@@ -8,13 +8,14 @@ import logging
 
 class RestorationTool:
 
-    def __init__(self, log_file, output_file, data_dir, uncompressed_archives):
+    def __init__(self, log_file, output_file, data_dir, uncompressed_archives, service_name):
         self.log_manager = log_manager.LogManager()
         self.data_dir = data_dir
         self.stop_watch = timer.Timer()
         self.setup_logging(log_file)
         self.command_executor = CommandExecutor(output_file)
         self.compressed_archives = not uncompressed_archives
+        self.service_name = service_name
 
     def setup_logging(self, log_file):
         self.logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ class RestorationTool:
 
     def stop_service(self):
         try:
-            self.command_executor.exec_manage_service('mysql', 'stop')
+            self.command_executor.exec_manage_service(self.service_name, 'stop')
         except:
             self.logger.error(
                 'Unable to manage MySQL service.',
@@ -128,7 +129,7 @@ class RestorationTool:
 
     def start_service(self):
         try:
-            self.command_executor.exec_manage_service('mysql', 'start')
+            self.command_executor.exec_manage_service(self.service_name, 'start')
         except:
             self.logger.error(
                 'Unable to manage MySQL service.',


### PR DESCRIPTION
This change is helpful when the service on the system that should be
restored uses a different name than 'mysql'.